### PR TITLE
Fix attribute writing order, enum type, and environmental variable tables

### DIFF
--- a/src/dbc/Writer.ts
+++ b/src/dbc/Writer.ts
@@ -310,6 +310,9 @@ class Writer {
       case 'STRING':
         lineContent = lineContent + ` "${value.defaultValue}";`;
         break;
+      case 'ENUM':
+        lineContent = lineContent + ` "${value.defaultValue}";`;
+        break;
       default:
         lineContent = lineContent + ` ${value.defaultValue};`;
         break;

--- a/src/dbc/Writer.ts
+++ b/src/dbc/Writer.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import {
   Attribute,
   AttributeDataType,
-  DbcData,
+  DbcData, EnvironmentVariable,
   Message,
   NetworkBridges,
   Signal,
@@ -48,6 +48,7 @@ class Writer {
     this.writeAttributeValues(data);
     this.writeSignalGroups(data.messages);
     this.writeSignalTables(data.messages);
+    this.writeEnvVarTables(data.environmentVariables);
   }
 
   /**
@@ -226,6 +227,16 @@ class Writer {
       }
     }
     this.writeLine('');
+  }
+
+  writeEnvVarTables(environmentVariables: Map<string, EnvironmentVariable>) {
+    environmentVariables.forEach((ev: EnvironmentVariable)=>{
+      if (ev.valueTable) {
+        const members = this.generateEnumTable(ev.valueTable);
+        const lineContent = `VAL_ ${ev.name} ${members};`;
+        this.writeLine(lineContent);
+      }
+    })
   }
 
   private enumListToString(enumList: string[]) {

--- a/src/dbc/Writer.ts
+++ b/src/dbc/Writer.ts
@@ -43,12 +43,11 @@ class Writer {
       this.writeBaseComment(data.description);
     }
     this.writeMessageAndSignalComments(data.messages);
-
-    this.writeSignalTables(data.messages);
     this.writeAttributeDefinitions(data);
     this.writeAttributeDefaults(data);
     this.writeAttributeValues(data);
     this.writeSignalGroups(data.messages);
+    this.writeSignalTables(data.messages);
   }
 
   /**


### PR DESCRIPTION
This pull request address an issue where certain attributes were not being written in the correct order to the file. Additionally, ENUM types were not surrounded with quotes when writing the BA_DEF_DEF_ attributes. Finally, environmental variable tables were not being written to the file.